### PR TITLE
Added missing fs-xattr to dev dependancies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "del": "^4.1.0",
     "follow-redirects": "^1.7.0",
     "fs-extra": "^7.0.1",
+    "fs-xattr": "^0.3.1",
     "git-rev-sync": "^1.12.0",
     "gulp": "^4.0.2",
     "gulp-concat": "^2.6.1",


### PR DESCRIPTION
When running the start script using the master branch I received node dependency errors looking for fs-xattr.

After adding it start script works again and runs on macOs